### PR TITLE
Start and stop Async reads on console out at will

### DIFF
--- a/src/Proc.Tests.Binary/Program.cs
+++ b/src/Proc.Tests.Binary/Program.cs
@@ -26,6 +26,7 @@ namespace Proc.Tests.Binary
 
 			if (testCase == nameof(ReadKeyFirst).ToLowerInvariant()) return ReadKeyFirst();
 			if (testCase == nameof(ReadKeyAfter).ToLowerInvariant()) return ReadKeyAfter();
+			if (testCase == nameof(SlowOutput).ToLowerInvariant()) return SlowOutput();
 			if (testCase == nameof(ReadLineFirst).ToLowerInvariant()) return ReadLineFirst();
 			if (testCase == nameof(ReadLineAfter).ToLowerInvariant()) return ReadLineAfter();
 			if (testCase == nameof(MoreText).ToLowerInvariant()) return MoreText();
@@ -91,6 +92,15 @@ namespace Proc.Tests.Binary
 			Console.Read();
 			Console.Write(nameof(ReadKeyAfter));
 			return 21;
+		}
+		private static int SlowOutput()
+		{
+			for (var i = 1; i <= 10; i++)
+			{
+				Console.WriteLine("x:" + i);
+				Thread.Sleep(500);
+			}
+			return 121;
 		}
 		private static int ReadLineFirst()
 		{

--- a/src/Proc.Tests/AsyncReadsStartStopTests.cs
+++ b/src/Proc.Tests/AsyncReadsStartStopTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProcNet.Std;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class AsyncReadsStartStopTests : TestsBase
+	{
+		[Fact]
+		public void SlowOutput()
+		{
+			var args = TestCaseArguments(nameof(SlowOutput));
+			var process = new ObservableProcess(args);
+			var consoleOut = new List<LineOut>();
+			Exception seenException = null;
+			process.SubscribeLines(c =>
+			{
+				consoleOut.Add(c);
+				if (!c.Line.EndsWith("3")) return;
+
+				process.CancelAsyncReads();
+				Task.Run(async () =>
+				{
+					await Task.Delay(TimeSpan.FromSeconds(2));
+					process.StartAsyncReads();
+				});
+			}, e=> seenException = e);
+
+			process.WaitForCompletion(TimeSpan.FromSeconds(20));
+
+			process.ExitCode.Should().HaveValue().And.Be(121);
+			seenException.Should().BeNull();
+			consoleOut.Should().NotBeEmpty()
+				//we stopped reads after 3 or 2 seconds
+				.And.NotContain(l => l.Line.EndsWith("4"))
+				//each line is delayed 500ms so after 2 seconds
+				//and subscribing again we should see 9
+				.And.Contain(l => l.Line.EndsWith("9"));
+		}
+	}
+}

--- a/src/Proc.Tests/ReadInOrderTests.cs
+++ b/src/Proc.Tests/ReadInOrderTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Serialization;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
+﻿using FluentAssertions;
 using Xunit;
 
 namespace ProcNet.Tests

--- a/src/Proc.sln
+++ b/src/Proc.sln
@@ -55,6 +55,8 @@ Global
 		{733EB608-B8B4-47FE-AB63-A4C7856C4209}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{733EB608-B8B4-47FE-AB63-A4C7856C4209}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{733EB608-B8B4-47FE-AB63-A4C7856C4209}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6997ADC-E933-418E-831C-DE1A78897493}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6997ADC-E933-418E-831C-DE1A78897493}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Proc/BufferedObservableProcess.cs
+++ b/src/Proc/BufferedObservableProcess.cs
@@ -102,9 +102,13 @@ namespace ProcNet
 			return disposable;
 		}
 
-		private object _lock = new object();
+		private readonly object _lock = new object();
 		private bool _reading = false;
 
+		/// <summary>
+		/// Allows you to stop reading the console output after subscribing on the observable while leaving the underlying
+		/// process running.
+		/// </summary>
 		public void CancelAsyncReads()
 		{
 			if (!this._reading) return;
@@ -127,14 +131,18 @@ namespace ProcNet
 			}
 		}
 
+		/// <summary>
+		/// Start reading the console output again after calling <see cref="CancelAsyncReads"/>
+		/// </summary>
 		public void StartAsyncReads()
 		{
 			if (this._reading) return;
 			lock (_lock)
 			{
 				if (this._reading) return;
-                this._stdOutSubscription = this.Process.ObserveStandardOutBuffered(_observer, BufferSize, ContinueReadingFromProcessReaders, _ctx.Token);
-                this._stdErrSubscription = this.Process.ObserveErrorOutBuffered(_observer, BufferSize, ContinueReadingFromProcessReaders, _ctx.Token);
+
+				this._stdOutSubscription = this.Process.ObserveStandardOutBuffered(_observer, BufferSize, ContinueReadingFromProcessReaders, _ctx.Token);
+				this._stdErrSubscription = this.Process.ObserveErrorOutBuffered(_observer, BufferSize, ContinueReadingFromProcessReaders, _ctx.Token);
 				this._reading = true;
 			}
 		}


### PR DESCRIPTION
Expose `CancelAsyncReads`  that will break the `StreamReader.ReadAsync` blocking in a thread at will.

`StreamReader.ReadAsync` does not expose a cancellationtoken even if the
underlying `Stream.ReadAsync` does. If you are no longer interested in
the console output you can now call `CancelAsyncReads` to break out of
the possibly blocking `StreamReader.ReadAsync` calls. Doing this will
leave the launched process running.

and `StartAsyncReads` allows you to resubscribe again.

cc @codebrain @russcam 