### PR TITLE
Add static support for long running processes

### DIFF
--- a/examples/ScratchPad.Fs/Program.fs
+++ b/examples/ScratchPad.Fs/Program.fs
@@ -1,11 +1,11 @@
 ﻿open System
 open Proc.Fs
 
+(*
 let _ = shell {
     exec "dotnet" "--version"
     exec "uname"
 }
-
 
 exec { run "dotnet" "--help"}
 
@@ -56,5 +56,14 @@ let _ = shell { exec "dotnet" args }
 let statusCode = exec { exit_code_of "dotnet" "--help"}
 
 exec { run "dotnet" "run" "--project" "examples/ScratchPad.Fs.ArgumentPrinter" "--" "With Space" }
+*)
+
+let runningProcess = exec {
+    binary "dotnet"
+    arguments "run" "--project" "tests/Proc.Tests.Binary" "--" "TrulyLongRunning"
+    //wait_until (fun l -> l.Line = "Started!")
+    wait_until_and_disconnect (fun l -> l.Line = "Started!")
+}
+
 
 printfn "That's all folks!"

--- a/examples/ScratchPad.Fs/Program.fs
+++ b/examples/ScratchPad.Fs/Program.fs
@@ -8,6 +8,7 @@ let _ = shell {
 
 
 exec { run "dotnet" "--help"}
+
 exec {
     binary "dotnet"
     arguments "--help"
@@ -38,7 +39,7 @@ let dotnetVersion = exec {
     filter (fun l -> l.Line.Contains "clean")
 }
 
-printfn "Found lines %i" dotnetVersion.Length
+printfn $"Found lines %i{dotnetVersion.Length}"
 
 
 let dotnetOptions = exec { binary "dotnet" }

--- a/src/Proc.Fs/README.md
+++ b/src/Proc.Fs/README.md
@@ -103,3 +103,24 @@ let helpOutput = exec {
 ```
 
 returns the exit code and the full console output.
+
+```fsharp
+
+let process = exec {
+    binary "dotnet"
+    arguments "--help"
+    wait_until (fun l -> l.Line.Contains "clean")
+}
+```
+
+returns an already running process but only after it confirms a line was printed
+```fsharp
+
+let process = exec {
+    binary "dotnet"
+    arguments "--help"
+    wait_until_and_disconnect (fun l -> l.Line.Contains "clean")
+}
+```
+
+returns an already running process but only after it confirms a line was printed. This version will stop the yielding standard/out lines which may utilize memory consumption which is no longer needed.

--- a/src/Proc/ExecArguments.cs
+++ b/src/Proc/ExecArguments.cs
@@ -10,9 +10,6 @@ namespace ProcNet
 
 		public ExecArguments(string binary, params string[] args) : base(binary, args) { }
 
-		/// <summary> Force arguments and the current working director NOT to be part of the exception message </summary>
-		public bool OnlyPrintBinaryInExceptionMessage { get; set; }
-
 		public Func<int, bool> ValidExitCodeClassifier
 		{
 			get => _validExitCodeClassifier ?? (c => c == 0);

--- a/src/Proc/LongRunningArguments.cs
+++ b/src/Proc/LongRunningArguments.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using ProcNet.Std;
+
+namespace ProcNet;
+
+public class LongRunningArguments : StartArguments
+{
+	public LongRunningArguments(string binary, IEnumerable<string> args) : base(binary, args) { }
+
+	public LongRunningArguments(string binary, params string[] args) : base(binary, args) { }
+
+	/// <summary>
+	/// A handler that will delay return of the <see cref="IDisposable"/> process until startup is confirmed over
+	/// standard out/error.
+	/// </summary>
+	public Func<LineOut, bool> StartedConfirmationHandler { get; set; }
+
+	/// <summary>
+	/// A helper that sets <see cref="StartArguments.KeepBufferingLines"/> and stops immediately after <see cref="StartedConfirmationHandler"/>
+	/// indicates the process has started.
+	/// </summary>
+	public bool StopBufferingAfterStarted { get; set; }
+}

--- a/src/Proc/ObservableProcess.cs
+++ b/src/Proc/ObservableProcess.cs
@@ -110,7 +110,12 @@ namespace ProcNet
 						)
 						.ToArray();
 				})
-				.TakeWhile(KeepBufferingLines)
+				.TakeWhile(l =>
+				{
+					var keepBuffering = StartArguments.KeepBufferingLines ?? KeepBufferingLines;
+					var keep = keepBuffering?.Invoke(l);
+					return keep.GetValueOrDefault(true);
+				})
 				.Where(l => l != null)
 				.Where(observeLinesFilter)
 				.Subscribe(

--- a/src/Proc/Proc.Start.cs
+++ b/src/Proc/Proc.Start.cs
@@ -10,29 +10,28 @@ namespace ProcNet
 	{
 		/// <summary>
 		/// Default timeout for all the process started through Proc.Start() or Proc.Exec().
-		/// Defaults to 10 minutes.
+		/// Defaults to infinity.
 		/// </summary>
-		public static TimeSpan DefaultTimeout { get; } = TimeSpan.FromMinutes(10);
+		public static TimeSpan DefaultTimeout { get; } = new(0, 0, 0, 0, -1);
 
 		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
+		/// <param name="bin">The binary to execute</param>
+		/// <param name="arguments">the commandline arguments to add to the invocation of <paramref name="bin"/></param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
 		public static ProcessCaptureResult Start(string bin, params string[] arguments) =>
 			Start(bin, DefaultTimeout, arguments);
 
 		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
+		/// <param name="bin">The binary to execute</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
+		/// <param name="arguments">the commandline arguments to add to the invocation of <paramref name="bin"/></param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
 		public static ProcessCaptureResult Start(string bin, TimeSpan timeout, params string[] arguments) =>
-			Start(bin, timeout, started: null, arguments: arguments);
+			Start(bin, timeout, null, arguments);
 
 		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
-		/// <param name="timeout">The maximum runtime of the started program</param>
-		/// <param name="started">A callback when the process is ready to receive standard in writes</param>
-		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
-		public static ProcessCaptureResult Start(string bin, TimeSpan timeout, StartedHandler started, params string[] arguments) =>
-			Start(bin, timeout, null, started, arguments);
-
-		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
+		/// <param name="bin">The binary to execute</param>
+		/// <param name="arguments">the commandline arguments to add to the invocation of <paramref name="bin"/></param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
 		/// <param name="consoleOutWriter">
 		/// An implementation of <see cref="IConsoleOutWriter"/> that takes care of writing to the console
@@ -40,53 +39,33 @@ namespace ProcNet
 		/// </param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
 		public static ProcessCaptureResult Start(string bin, TimeSpan timeout, IConsoleOutWriter consoleOutWriter, params string[] arguments) =>
-			Start(bin, timeout, consoleOutWriter, started: null, arguments: arguments);
+			Start(new StartArguments(bin, arguments), timeout, consoleOutWriter);
 
 		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
-		/// <param name="timeout">The maximum runtime of the started program</param>
-		/// <param name="started">A callback when the process is ready to receive standard in writes</param>
-		/// <param name="consoleOutWriter">
-		/// An implementation of <see cref="IConsoleOutWriter"/> that takes care of writing to the console
-		/// <para>defaults to <see cref="ConsoleOutColorWriter"/> which writes standard error messages in red</para>
-		/// </param>
-		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
-		public static ProcessCaptureResult Start(string bin, TimeSpan timeout, IConsoleOutWriter consoleOutWriter, StartedHandler started, params string[] arguments) =>
-			Start(new StartArguments(bin, arguments), timeout, consoleOutWriter, started);
-
-		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
 		public static ProcessCaptureResult Start(StartArguments arguments) => Start(arguments, DefaultTimeout);
 
 		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
 		public static ProcessCaptureResult Start(StartArguments arguments, TimeSpan timeout) =>
 			Start(arguments, timeout, null);
 
 		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
 		/// <param name="consoleOutWriter">
 		/// An implementation of <see cref="IConsoleOutWriter"/> that takes care of writing to the console
 		/// <para>defaults to <see cref="ConsoleOutColorWriter"/> which writes standard error messages in red</para>
 		/// </param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
-		public static ProcessCaptureResult Start(StartArguments arguments, TimeSpan timeout, IConsoleOutWriter consoleOutWriter) =>
-			Start(arguments, timeout, consoleOutWriter, null);
-
-		/// <summary> Starts a program and captures the output while writing to the console in realtime during execution </summary>
-		/// <param name="timeout">The maximum runtime of the started program</param>
-		/// <param name="started">A callback when the process is ready to receive standard in writes</param>
-		/// <param name="consoleOutWriter">
-		/// An implementation of <see cref="IConsoleOutWriter"/> that takes care of writing to the console
-		/// <para>defaults to <see cref="ConsoleOutColorWriter"/> which writes standard error messages in red</para>
-		/// </param>
-		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
-		public static ProcessCaptureResult Start(StartArguments arguments, TimeSpan timeout, IConsoleOutWriter consoleOutWriter, StartedHandler started)
+		public static ProcessCaptureResult Start(StartArguments arguments, TimeSpan timeout, IConsoleOutWriter consoleOutWriter)
 		{
 			using var composite = new CompositeDisposable();
 			var process = new ObservableProcess(arguments);
-			if (started != null) process.ProcessStarted += started;
-			consoleOutWriter = consoleOutWriter ?? new ConsoleOutColorWriter();
+			consoleOutWriter ??= new ConsoleOutColorWriter();
 
 			Exception seenException = null;
 			var consoleOut = new List<LineOut>();
@@ -97,8 +76,8 @@ namespace ProcNet
 						consoleOut.Add(l);
 					},
 					e => seenException = e,
-					consoleOutWriter.Write,
-					consoleOutWriter.Write
+					l => consoleOutWriter.Write(l),
+					l => consoleOutWriter.Write(l)
 				)
 			);
 

--- a/src/Proc/Proc.StartLongRunning.cs
+++ b/src/Proc/Proc.StartLongRunning.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Reactive.Disposables;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using ProcNet.Extensions;
+using ProcNet.Std;
+
+namespace ProcNet
+{
+	public static partial class Proc
+	{
+
+		/// <summary>
+		/// Allows you to start long running processes and dispose them when needed.
+		/// <para> It also optionally allows you to wait <paramref name="waitForStartedConfirmation"/> before returning the disposable
+		/// by inspecting the console out of the process to validate the 'true' starting confirmation of the process using
+		/// <see cref="LongRunningArguments.StartedConfirmationHandler"/>
+		/// </para>
+		/// <para>
+		/// A usecase for this could be starting a webserver or database and wait before it prints it startup confirmation
+		/// before returning.
+		/// </para>
+		/// </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
+		/// <param name="waitForStartedConfirmation">Waits returning the <see cref="IDisposable"/> before <see cref="LongRunningArguments.StartedConfirmationHandler"/> confirms the process started</param>
+		/// <param name="consoleOutWriter">
+		/// An implementation of <see cref="IConsoleOutWriter"/> that takes care of writing to the console
+		/// <para>defaults to <see cref="ConsoleOutColorWriter"/> which writes standard error messages in red</para>
+		/// </param>
+		/// <returns>The exit code and whether the process completed</returns>
+		public static IDisposable StartLongRunning(LongRunningArguments arguments, TimeSpan waitForStartedConfirmation, IConsoleOutWriter consoleOutWriter = null)
+		{
+			var started = false;
+			var confirmWaitHandle = new ManualResetEvent(false);
+			var composite = new CompositeDisposable();
+			var process = new ObservableProcess(arguments);
+			consoleOutWriter ??= new ConsoleOutColorWriter();
+
+			var startedConfirmation = arguments.StartedConfirmationHandler ?? (_ => true);
+
+			if (arguments.StartedConfirmationHandler != null && arguments.StopBufferingAfterStarted)
+				arguments.KeepBufferingLines = _ => !started;
+
+			Exception seenException = null;
+			composite.Add(process);
+			composite.Add(process.SubscribeLinesAndCharacters(
+					l =>
+					{
+						if (startedConfirmation(l))
+						{
+							confirmWaitHandle.Set();
+							started = true;
+						}
+					},
+					e =>
+					{
+						seenException = e;
+						confirmWaitHandle.Set();
+					},
+					l => consoleOutWriter.Write(l),
+					l => consoleOutWriter.Write(l)
+					)
+			);
+
+			if (seenException != null) ExceptionDispatchInfo.Capture(seenException).Throw();
+			if (arguments.StartedConfirmationHandler == null)
+			{
+				confirmWaitHandle.Set();
+				started = true;
+			}
+			else
+			{
+				 var completed = confirmWaitHandle.WaitOne(waitForStartedConfirmation);
+				 if (completed) return composite;
+				 var pwd = arguments.WorkingDirectory;
+				 var args = arguments.Args.NaivelyQuoteArguments();
+				 var printBinary = arguments.OnlyPrintBinaryInExceptionMessage
+					 ? $"\"{arguments.Binary}\""
+					 : $"\"{arguments.Binary} {args}\"{(pwd == null ? string.Empty : $" pwd: {pwd}")}";
+				 throw new ProcExecException($"Could not yield started confirmation after {waitForStartedConfirmation} while running {printBinary}");
+			}
+
+			return composite;
+		}
+	}
+}

--- a/src/Proc/Proc.StartRedirected.cs
+++ b/src/Proc/Proc.StartRedirected.cs
@@ -22,66 +22,71 @@ namespace ProcNet
 		/// Start a program and get notified of lines in realtime through <see cref="lineHandler"/> unlike <see cref="Start(string,string[])"/>
 		/// This won't capture all lines on the returned object and won't default to writing to the Console.
 		/// </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
 		/// <param name="lineH"andler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
 		/// <returns>The exit code and whether the process completed</returns>
 		public static ProcessResult StartRedirected(IConsoleLineHandler lineHandler, string bin, TimeSpan timeout, params string[] arguments) =>
-			StartRedirected(lineHandler, bin, timeout, started: null, arguments: arguments);
+			StartRedirected(lineHandler, bin, timeout, standardInput: null, arguments: arguments);
 
 		/// <summary>
 		/// Start a program and get notified of lines in realtime through <paramref name="lineHandler"/> unlike <see cref="Start(string,string[])"/>
 		/// This won't capture all lines on the returned object and won't default to writing to the Console.
 		/// </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
-		/// <param name="started">A callback when the process is ready to receive standard in writes</param>
+		/// <param name="standardInput">A callback when the process is ready to receive standard in writes</param>
 		/// <param name="lineHandler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
 		/// <returns>The exit code and whether the process completed</returns>
-		public static ProcessResult StartRedirected(IConsoleLineHandler lineHandler, string bin, TimeSpan timeout, StartedHandler started, params string[] arguments) =>
-			StartRedirected(new StartArguments(bin, arguments), timeout, started, lineHandler);
+		public static ProcessResult StartRedirected(IConsoleLineHandler lineHandler, string bin, TimeSpan timeout, StandardInputHandler standardInput, params string[] arguments) =>
+			StartRedirected(new StartArguments(bin, arguments), timeout, standardInput, lineHandler);
 
 		/// <summary>
 		/// Start a program and get notified of lines in realtime through <paramref name="lineHandler"/> unlike <see cref="Start(string,string[])"/>
 		/// This won't capture all lines on the returned object and won't default to writing to the Console.
 		/// </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="lineHandler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
 		/// <returns>The exit code and whether the process completed</returns>
 		public static ProcessResult StartRedirected(StartArguments arguments, IConsoleLineHandler lineHandler = null) =>
-			StartRedirected(arguments, DefaultTimeout, started: null, lineHandler: lineHandler);
+			StartRedirected(arguments, DefaultTimeout, standardInput: null, lineHandler: lineHandler);
 
 		/// <summary>
 		/// Start a program and get notified of lines in realtime through <paramref name="lineHandler"/> unlike <see cref="Start(string,string[])"/>
 		/// This won't capture all lines on the returned object and won't default to writing to the Console.
 		/// </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
 		/// <param name="lineHandler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
 		/// <returns>The exit code and whether the process completed</returns>
 		public static ProcessResult StartRedirected(StartArguments arguments, TimeSpan timeout, IConsoleLineHandler lineHandler = null) =>
-			StartRedirected(arguments, timeout, started: null, lineHandler: lineHandler);
+			StartRedirected(arguments, timeout, standardInput: null, lineHandler: lineHandler);
 
 		/// <summary>
 		/// Start a program and get notified of lines in realtime through <paramref name="lineHandler"/> unlike <see cref="Start(string,string[])"/>
 		/// This won't capture all lines on the returned object and won't default to writing to the Console.
 		/// </summary>
+		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
 		/// <param name="timeout">The maximum runtime of the started program</param>
-		/// <param name="started">A callback when the process is ready to receive standard in writes</param>
+		/// <param name="standardInput">A callback when the process is ready to receive standard in writes</param>
 		/// <param name="lineHandler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
 		/// <returns>The exit code and whether the process completed</returns>
-		public static ProcessResult StartRedirected(StartArguments arguments, TimeSpan timeout, StartedHandler started, IConsoleLineHandler lineHandler = null)
+		public static ProcessResult StartRedirected(StartArguments arguments, TimeSpan timeout, StandardInputHandler standardInput, IConsoleLineHandler lineHandler = null)
 		{
 			using (var composite = new CompositeDisposable())
 			{
 				var process = new ObservableProcess(arguments);
-				if (started != null) process.ProcessStarted += started;
+				if (standardInput != null) process.StandardInputReady += standardInput;
 
 				Exception seenException = null;
 				composite.Add(process);

--- a/src/Proc/ProcessArgumentsBase.cs
+++ b/src/Proc/ProcessArgumentsBase.cs
@@ -21,5 +21,9 @@ namespace ProcNet
 
 		/// <summary> Set the current working directory</summary>
 		public string WorkingDirectory { get; set; }
+
+		/// <summary> Force arguments and the current working director NOT to be part of the exception message </summary>
+		public bool OnlyPrintBinaryInExceptionMessage { get; set; }
+
 	}
 }

--- a/src/Proc/StartArguments.cs
+++ b/src/Proc/StartArguments.cs
@@ -22,6 +22,15 @@ namespace ProcNet
 		/// </summary>
 		public bool NoWrapInThread { get; set; }
 
+		/// <summary>
+		/// return true to stop buffering lines. Allows callers to optionally short circuit reading
+		/// from stdout/stderr without closing the process.
+		/// This is great for long running processes to only buffer console output until
+		/// all information is parsed.
+		/// </summary>
+		/// <returns>True to end the buffering of char[] to lines of text</returns>
+		public Func<LineOut, bool> KeepBufferingLines { get; set; }
+
 		/// <summary> Attempts to send control+c (SIGINT) to the process first </summary>
 		public bool SendControlCFirst { get; set; }
 
@@ -30,6 +39,11 @@ namespace ProcNet
 		/// Defaults to true meaning all all lines.
 		/// </summary>
 		public Func<LineOut, bool> LineOutFilter { get; set; }
+
+		/// <summary>
+		/// Callback with a reference to standard in once the process has started and stdin can be written too
+		/// </summary>
+		public StandardInputHandler StandardInputHandler { get; set; }
 
 		private static readonly TimeSpan DefaultWaitForExit = TimeSpan.FromSeconds(10);
 

--- a/tests/Proc.Tests.Binary/Program.cs
+++ b/tests/Proc.Tests.Binary/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,7 +8,7 @@ namespace Proc.Tests.Binary
 {
 	public static class Program
 	{
-		public static int Main(string[] args)
+		public static async Task<int> Main(string[] args)
 		{
 			if (args.Length == 0)
 			{
@@ -35,6 +36,8 @@ namespace Proc.Tests.Binary
 			if (testCase == nameof(ControlCNoWait).ToLowerInvariant()) return ControlCNoWait();
 			if (testCase == nameof(OverwriteLines).ToLowerInvariant()) return OverwriteLines();
 			if (testCase == nameof(InterMixedOutAndError).ToLowerInvariant()) return InterMixedOutAndError();
+			if (testCase == nameof(LongRunning).ToLowerInvariant()) return await LongRunning();
+			if (testCase == nameof(TrulyLongRunning).ToLowerInvariant()) return await TrulyLongRunning();
 
 			return 1;
 		}
@@ -144,6 +147,42 @@ namespace Proc.Tests.Binary
 			Console.Write(output);
 
 			return 60;
+		}
+
+		private static async Task<int> LongRunning()
+		{
+			for (var i = 0; i < 10; i++)
+			{
+				Console.WriteLine($"Starting up: {i}");
+				await Task.Delay(20);
+			}
+			Console.WriteLine($"Started!");
+			await Task.Delay(20);
+			for (var i = 0; i < 10; i++)
+			{
+				Console.WriteLine($"Data after startup: {i}");
+				await Task.Delay(20);
+			}
+
+
+			return 0;
+		}
+
+		private static async Task<int> TrulyLongRunning()
+		{
+			for (var i = 0; i < 2; i++)
+			{
+				Console.WriteLine($"Starting up: {i}");
+				await Task.Delay(TimeSpan.FromSeconds(1));
+			}
+			Console.WriteLine($"Started!");
+			await Task.Delay(TimeSpan.FromSeconds(3));
+			for (var i = 0; i < 10; i++)
+			{
+				Console.WriteLine($"Data after startup: {i}");
+				await Task.Delay(TimeSpan.FromSeconds(10));
+			}
+			return 0;
 		}
 
 		private static int MoreText()

--- a/tests/Proc.Tests/LongRunningTests.cs
+++ b/tests/Proc.Tests/LongRunningTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProcNet.Std;
+using FluentAssertions;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class LongRunningTests : TestsBase
+	{
+		[Fact]
+		public async Task LongRunningShouldSeeAllOutput()
+		{
+			var args = LongRunningTestCaseArguments("LongRunning");
+			args.StartedConfirmationHandler = l => l.Line == "Started!";
+
+			var outputWriter = new LineOutputTestCases.TestConsoleOutWriter();
+			using (var result = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+				await Task.Delay(TimeSpan.FromSeconds(2));
+
+			var lines = outputWriter.Lines;
+			lines.Length.Should().BeGreaterThan(0);
+			lines.Should().Contain(s => s.StartsWith("Starting up:"));
+			lines.Should().Contain(s => s == "Started!");
+			lines.Should().Contain(s => s.StartsWith("Data after startup:"));
+		}
+
+		[Fact]
+		public async Task LongRunningShouldStopBufferingOutputWhenAsked()
+		{
+			var args = LongRunningTestCaseArguments("TrulyLongRunning");
+			args.StartedConfirmationHandler = l => l.Line == "Started!";
+			args.StopBufferingAfterStarted = true;
+
+			var outputWriter = new LineOutputTestCases.TestConsoleOutWriter();
+			var sw = Stopwatch.StartNew();
+
+			using (var result = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+			{
+				sw.Elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(1));
+				var lines = outputWriter.Lines;
+				lines.Length.Should().BeGreaterThan(0);
+				lines.Should().Contain(s => s.StartsWith("Starting up:"));
+				lines.Should().Contain(s => s == "Started!");
+				lines.Should().NotContain(s => s.StartsWith("Data after startup:"));
+				await Task.Delay(TimeSpan.FromSeconds(2));
+				lines.Should().NotContain(s => s.StartsWith("Data after startup:"));
+			}
+			// we dispose before the program's completion
+			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(20));
+
+		}
+
+		[Fact]
+		public async Task LongRunningWithoutConfirmationHandler()
+		{
+			var args = LongRunningTestCaseArguments("LongRunning");
+			var outputWriter = new LineOutputTestCases.TestConsoleOutWriter();
+
+			using (var result = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+				await Task.Delay(TimeSpan.FromSeconds(2));
+
+			var lines = outputWriter.Lines;
+			lines.Should().Contain(s => s.StartsWith("Starting up:"));
+			lines.Should().Contain(s => s == "Started!");
+			lines.Should().Contain(s => s.StartsWith("Data after startup:"));
+			lines.Length.Should().BeGreaterThan(0);
+		}
+	}
+}

--- a/tests/Proc.Tests/ProcTestCases.cs
+++ b/tests/Proc.Tests/ProcTestCases.cs
@@ -23,8 +23,9 @@ namespace ProcNet.Tests
 		public void ReadKeyFirst()
 		{
 			var args = TestCaseArguments(nameof(ReadKeyFirst));
+			args.StandardInputHandler = s => s.Write("y");
 			var writer = new TestConsoleOutWriter();
-			var result = Proc.Start(args, WaitTimeout, writer, s => s.Write("y"));
+			var result = Proc.Start(args, WaitTimeout, writer);
 			result.Completed.Should().BeTrue("completed");
 			result.ExitCode.Should().HaveValue();
 			result.ConsoleOut.Should().NotBeEmpty();

--- a/tests/Proc.Tests/ReadLineTestCases.cs
+++ b/tests/Proc.Tests/ReadLineTestCases.cs
@@ -12,7 +12,7 @@ namespace ProcNet.Tests
 		{
 			var seen = new List<string>();
 			var process = new ObservableProcess(TestCaseArguments(nameof(ReadKeyFirst)));
-			process.ProcessStarted += (standardInput) =>
+			process.StandardInputReady += (standardInput) =>
 			{
 				//this particular program does not output anything and expect user input immediatly
 				//OnNext on the observable is only called on output so we need to write on the started event

--- a/tests/Proc.Tests/TestsBase.cs
+++ b/tests/Proc.Tests/TestsBase.cs
@@ -26,7 +26,13 @@ namespace ProcNet.Tests
 		}
 
 		protected static StartArguments TestCaseArguments(string testcase) =>
-			new StartArguments("dotnet", GetDll(), testcase)
+			new("dotnet", GetDll(), testcase)
+			{
+				WorkingDirectory = GetWorkingDir(),
+			};
+
+		protected static LongRunningArguments LongRunningTestCaseArguments(string testcase) =>
+			new("dotnet", GetDll(), testcase)
 			{
 				WorkingDirectory = GetWorkingDir(),
 			};


### PR DESCRIPTION
- Add static support for long running programs with manual started confirmations
- add fsharp bindings


This exposes static methods and fsharp bindings that allow you to start and wait for processes 'truly' starting and keep the running processes active until the return is disposed.
