### PR TITLE
Proc.StartLongRunning allows you to yield after waiting for started.

### DIFF
--- a/src/Proc/ObservableProcess.cs
+++ b/src/Proc/ObservableProcess.cs
@@ -143,11 +143,12 @@ namespace ProcNet
 		public virtual IDisposable SubscribeLinesAndCharacters(
 			Action<LineOut> onNext, Action<Exception> onError,
 			Action<CharactersOut> onNextCharacters,
-			Action<Exception> onExceptionCharacters
-			) =>
+			Action<Exception> onExceptionCharacters,
+			Action? onCompleted = null
+		) =>
 			Subscribe(
-				Observer.Create(onNext, onError, delegate { }),
-				Observer.Create(onNextCharacters, onExceptionCharacters, delegate { })
+				Observer.Create(onNext, onError, onCompleted ?? delegate { }),
+				Observer.Create(onNextCharacters, onExceptionCharacters, onCompleted ?? delegate { })
 			);
 
 		public virtual IDisposable SubscribeLines(Action<LineOut> onNext) =>

--- a/tests/Proc.Tests/LineOutputTests.cs
+++ b/tests/Proc.Tests/LineOutputTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using FluentAssertions;
 using ProcNet.Std;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ProcNet.Tests
 {
@@ -19,7 +19,7 @@ namespace ProcNet.Tests
 	}
 
 
-	public class LineOutputTestCases : TestsBase
+	public class LineOutputTestCases(ITestOutputHelper output) : TestsBase
 	{
 		private static readonly string _expected = @"
 Windows IP Configuration
@@ -99,7 +99,7 @@ Ethernet adapter Bluetooth Network Connection:
 		[Fact]
 		public void ConsoleWriterSeesAllLines()
 		{
-			var writer = new TestConsoleOutWriter();
+			var writer = new TestConsoleOutWriter(output);
 			var args = TestCaseArguments("MoreText");
 			var result = Proc.Start(args, WaitTimeout, writer);
 			result.ExitCode.Should().HaveValue();
@@ -110,15 +110,5 @@ Ethernet adapter Bluetooth Network Connection:
 				lines[i].Should().Be(_expectedLines[i], i.ToString());
 		}
 
-		public class TestConsoleOutWriter : IConsoleOutWriter
-		{
-			private readonly StringBuilder _sb = new StringBuilder();
-			public string[] Lines => _sb.ToString().Replace("\r\n", "\n").Split(new [] {"\n"}, StringSplitOptions.None);
-			public string Text => _sb.ToString();
-
-			public void Write(Exception e) => throw e;
-
-			public void Write(ConsoleOut consoleOut) => consoleOut.CharsOrString(c=>_sb.Append(new string(c)), s=>_sb.AppendLine(s));
-		}
 	}
 }

--- a/tests/Proc.Tests/LongRunningTests.cs
+++ b/tests/Proc.Tests/LongRunningTests.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using ProcNet.Std;
-using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ProcNet.Tests
 {
-	public class LongRunningTests : TestsBase
+	public class LongRunningTests(ITestOutputHelper output) : TestsBase
 	{
 		[Fact]
 		public async Task LongRunningShouldSeeAllOutput()
@@ -17,9 +15,14 @@ namespace ProcNet.Tests
 			var args = LongRunningTestCaseArguments("LongRunning");
 			args.StartedConfirmationHandler = l => l.Line == "Started!";
 
-			var outputWriter = new LineOutputTestCases.TestConsoleOutWriter();
-			using (var result = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+			var outputWriter = new TestConsoleOutWriter(output);
+
+			using (var process = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+			{
+				process.Running.Should().BeTrue();
 				await Task.Delay(TimeSpan.FromSeconds(2));
+				process.Running.Should().BeFalse();
+			}
 
 			var lines = outputWriter.Lines;
 			lines.Length.Should().BeGreaterThan(0);
@@ -35,11 +38,12 @@ namespace ProcNet.Tests
 			args.StartedConfirmationHandler = l => l.Line == "Started!";
 			args.StopBufferingAfterStarted = true;
 
-			var outputWriter = new LineOutputTestCases.TestConsoleOutWriter();
+			var outputWriter = new TestConsoleOutWriter(output);
 			var sw = Stopwatch.StartNew();
 
-			using (var result = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+			using (var process = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
 			{
+				process.Running.Should().BeTrue();
 				sw.Elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(1));
 				var lines = outputWriter.Lines;
 				lines.Length.Should().BeGreaterThan(0);
@@ -49,6 +53,7 @@ namespace ProcNet.Tests
 				await Task.Delay(TimeSpan.FromSeconds(2));
 				lines.Should().NotContain(s => s.StartsWith("Data after startup:"));
 			}
+
 			// we dispose before the program's completion
 			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(20));
 
@@ -58,10 +63,13 @@ namespace ProcNet.Tests
 		public async Task LongRunningWithoutConfirmationHandler()
 		{
 			var args = LongRunningTestCaseArguments("LongRunning");
-			var outputWriter = new LineOutputTestCases.TestConsoleOutWriter();
+			var outputWriter = new TestConsoleOutWriter(output);
 
-			using (var result = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+			using (var process = Proc.StartLongRunning(args, WaitTimeout, outputWriter))
+			{
+				process.Running.Should().BeTrue();
 				await Task.Delay(TimeSpan.FromSeconds(2));
+			}
 
 			var lines = outputWriter.Lines;
 			lines.Should().Contain(s => s.StartsWith("Starting up:"));

--- a/tests/Proc.Tests/TestConsoleOutWriter.cs
+++ b/tests/Proc.Tests/TestConsoleOutWriter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text;
+using ProcNet.Std;
+using Xunit.Abstractions;
+
+public class TestConsoleOutWriter(ITestOutputHelper output) : IConsoleOutWriter
+{
+	private readonly StringBuilder _sb = new();
+	public string[] Lines => _sb.ToString().Replace("\r\n", "\n").Split(new [] {"\n"}, StringSplitOptions.None);
+	public string Text => _sb.ToString();
+
+	public void Write(Exception e) => throw e;
+
+	public void Write(ConsoleOut consoleOut)
+	{
+		consoleOut.CharsOrString(c => _sb.Append(new string(c)), s => _sb.AppendLine(s));
+		consoleOut.CharsOrString(c => output.WriteLine(new string(c)), output.WriteLine);
+	}
+}


### PR DESCRIPTION
Without necessarily killing the process (unless disposing the long running subscription).

Its now also easier to stop buffering process output after started handler (optional)
