### PR TITLE
reproduce/quoted

### DIFF
--- a/src/Proc/BufferedObservableProcess.cs
+++ b/src/Proc/BufferedObservableProcess.cs
@@ -74,11 +74,14 @@ namespace ProcNet
 
 			if (Process.HasExited)
 			{
+				Process.ReadStandardErrBlocking(_observer, BufferSize, () => ContinueReadingFromProcessReaders());
+				Process.ReadStandardOutBlocking(_observer, BufferSize, () => ContinueReadingFromProcessReaders());
 				OnExit(observer);
 				return Disposable.Empty;
 			}
 
 			_observer = observer;
+
 			StartAsyncReads();
 
 			Process.Exited += (o, s) =>

--- a/src/Proc/Extensions/ArgumentExtensions.cs
+++ b/src/Proc/Extensions/ArgumentExtensions.cs
@@ -1,7 +1,5 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace ProcNet.Extensions;
 

--- a/src/Proc/ObservableProcess.cs
+++ b/src/Proc/ObservableProcess.cs
@@ -144,7 +144,7 @@ namespace ProcNet
 			Action<LineOut> onNext, Action<Exception> onError,
 			Action<CharactersOut> onNextCharacters,
 			Action<Exception> onExceptionCharacters,
-			Action? onCompleted = null
+			Action onCompleted = null
 		) =>
 			Subscribe(
 				Observer.Create(onNext, onError, onCompleted ?? delegate { }),

--- a/src/Proc/Proc.Exec.cs
+++ b/src/Proc/Proc.Exec.cs
@@ -51,14 +51,13 @@ namespace ProcNet
 			var info = new ProcessStartInfo(arguments.Binary)
 			{
 				UseShellExecute = false
-				#if !NETSTANDARD2_1
-				, Arguments = args
-				#endif
 			};
-			#if NETSTANDARD2_1
+#if NETSTANDARD2_1
 			foreach (var arg in arguments.Args)
 				info.ArgumentList.Add(arg);
-			#endif
+#else
+			info.Arguments = args;
+#endif
 
 			var pwd = arguments.WorkingDirectory;
 			if (!string.IsNullOrWhiteSpace(pwd)) info.WorkingDirectory = pwd;
@@ -93,6 +92,7 @@ namespace ProcNet
 
 			return exitCode;
 		}
+
 		private static void HardWaitForExit(Process process, TimeSpan timeSpan)
 		{
 			using var task = Task.Run(() => process.WaitForExit());

--- a/tests/Proc.Tests.Binary/Program.cs
+++ b/tests/Proc.Tests.Binary/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,7 @@ namespace Proc.Tests.Binary
 
 			var testCase = args[0].ToLowerInvariant();
 
+			if (testCase == nameof(PrintArgs).ToLowerInvariant()) return PrintArgs(args.Skip(1).ToArray());
 			if (testCase == nameof(SingleLineNoEnter).ToLowerInvariant()) return SingleLineNoEnter();
 			if (testCase == nameof(TwoWrites).ToLowerInvariant()) return TwoWrites();
 
@@ -40,6 +42,12 @@ namespace Proc.Tests.Binary
 			if (testCase == nameof(TrulyLongRunning).ToLowerInvariant()) return await TrulyLongRunning();
 
 			return 1;
+		}
+		private static int PrintArgs(string[] args)
+		{
+			foreach (var arg in args)
+				Console.WriteLine(arg);
+			return 0;
 		}
 		private static int DelayedWriter()
 		{

--- a/tests/Proc.Tests/PrintArgsTests.cs
+++ b/tests/Proc.Tests/PrintArgsTests.cs
@@ -26,6 +26,12 @@ public class PrintArgsTests(ITestOutputHelper output) : TestsBase
 		string[] testArgs = ["this argument has spaces", "hello", "world"];
 		AssertOutput(testArgs);
 	}
+	[Fact]
+	public void EscapedQuotes()
+	{
+		string[] testArgs = ["\"this argument has spaces\"", "hello", "world"];
+		AssertOutput(testArgs);
+	}
 
 	private void AssertOutput(string[] testArgs)
 	{

--- a/tests/Proc.Tests/PrintArgsTests.cs
+++ b/tests/Proc.Tests/PrintArgsTests.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProcNet.Tests;
+
+public class PrintArgsTests(ITestOutputHelper output) : TestsBase
+{
+	[Fact]
+	public void ProcSendsAllArguments()
+	{
+		string[] testArgs = ["hello", "world"];
+		AssertOutput(testArgs);
+	}
+
+	[Fact]
+	public void ArgumentsWithSpaceAreNotSplit()
+	{
+		string[] testArgs = ["hello", "world", "this argument has spaces"];
+		AssertOutput(testArgs);
+	}
+
+	[Fact]
+	public void ArgumentsSeesArgumentsAfterQuoted()
+	{
+		string[] testArgs = ["this argument has spaces", "hello", "world"];
+		AssertOutput(testArgs);
+	}
+
+	private void AssertOutput(string[] testArgs)
+	{
+		var args = TestCaseArguments("PrintArgs", testArgs);
+		var outputWriter = new TestConsoleOutWriter(output);
+		var result = Proc.Start(args, WaitTimeout, outputWriter);
+		result.ExitCode.Should().Be(0);
+		result.ConsoleOut.Should().NotBeEmpty().And.HaveCount(testArgs.Length);
+		for (var i = 0; i < result.ConsoleOut.Count; i++)
+			result.ConsoleOut[i].Line.Should().Be(testArgs[i], i.ToString());
+	}
+
+}

--- a/tests/Proc.Tests/Proc.Tests.csproj
+++ b/tests/Proc.Tests/Proc.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net462; net8.0</TargetFrameworks>
     <AssemblyName>Proc.Tests</AssemblyName>
     <RootNamespace>ProcNet.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Proc\Proc.csproj" />

--- a/tests/Proc.Tests/Proc.Tests.csproj
+++ b/tests/Proc.Tests/Proc.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462; net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Proc.Tests</AssemblyName>
     <RootNamespace>ProcNet.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/tests/Proc.Tests/TestConsoleOutWriter.cs
+++ b/tests/Proc.Tests/TestConsoleOutWriter.cs
@@ -8,12 +8,13 @@ public class TestConsoleOutWriter(ITestOutputHelper output) : IConsoleOutWriter
 	private readonly StringBuilder _sb = new();
 	public string[] Lines => _sb.ToString().Replace("\r\n", "\n").Split(new [] {"\n"}, StringSplitOptions.None);
 	public string Text => _sb.ToString();
+	private static char[] NewLineChars = Environment.NewLine.ToCharArray();
 
 	public void Write(Exception e) => throw e;
 
 	public void Write(ConsoleOut consoleOut)
 	{
 		consoleOut.CharsOrString(c => _sb.Append(new string(c)), s => _sb.AppendLine(s));
-		consoleOut.CharsOrString(c => output.WriteLine(new string(c)), output.WriteLine);
+		consoleOut.CharsOrString(c => output.WriteLine(new string(c).TrimEnd(NewLineChars)), s => output.WriteLine(s));
 	}
 }

--- a/tests/Proc.Tests/TestsBase.cs
+++ b/tests/Proc.Tests/TestsBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace ProcNet.Tests
@@ -25,11 +26,15 @@ namespace ProcNet.Tests
 			return binaryFolder;
 		}
 
-		protected static StartArguments TestCaseArguments(string testcase) =>
-			new("dotnet", GetDll(), testcase)
+		protected static StartArguments TestCaseArguments(string testcase, params string[] args)
+		{
+			string[] arguments = [GetDll(), testcase];
+
+			return new StartArguments("dotnet", arguments.Concat(args))
 			{
 				WorkingDirectory = GetWorkingDir(),
 			};
+		}
 
 		protected static LongRunningArguments LongRunningTestCaseArguments(string testcase) =>
 			new("dotnet", GetDll(), testcase)


### PR DESCRIPTION
Attempt to no avail to reproduce #15, handling of quoted strings. 

Added special cases handling for when applications exit before we can attach the stdout/err streamreaders. In that case we simply drain the streams in a blocking fashion.
