### PR TITLE
Fix 'The pipe is being closed' IOException

### DIFF
--- a/src/Proc/ObservableProcessBase.cs
+++ b/src/Proc/ObservableProcessBase.cs
@@ -248,6 +248,7 @@ namespace ProcNet
 				}
 				//best effort
 				catch (InvalidOperationException) { }
+				catch (IOException) { }
 			}
 		}
 

--- a/tests/Proc.Tests/ControlCTestCases.cs
+++ b/tests/Proc.Tests/ControlCTestCases.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using FluentAssertions;
-using Xunit;
 
 namespace ProcNet.Tests
 {
@@ -24,6 +24,7 @@ namespace ProcNet.Tests
 			seen[0].Should().Be("Written before control+c");
 			seen[1].Should().Be("Written after control+c");
 		}
+
 		[SkipOnNonWindowsFact] public void ControlCSend()
 		{
 			var args = TestCaseArguments(nameof(ControlC));
@@ -49,7 +50,6 @@ namespace ProcNet.Tests
 			args.SendControlCFirst = true;
 
 			var process = new ObservableProcess(args);
-
 			var seen = new List<string>();
 			process.SubscribeLines(c=>
 			{
@@ -62,5 +62,18 @@ namespace ProcNet.Tests
 			seen[0].Should().Be("Written before control+c");
 		}
 
+		[SkipOnNonWindowsFact]
+		public void ControlCIngoredByCmd() {
+			var args = CmdTestCaseArguments("TrulyLongRunning");
+			args.SendControlCFirst = true;
+			args.WaitForExit = TimeSpan.FromSeconds(2);
+			
+			var process = new ObservableProcess(args);
+			process.SubscribeLines(c => { });
+
+			Action call = () => process.WaitForCompletion(TimeSpan.FromSeconds(1));
+
+			call.ShouldNotThrow<IOException>();
+		}
 	}
 }

--- a/tests/Proc.Tests/TestsBase.cs
+++ b/tests/Proc.Tests/TestsBase.cs
@@ -26,6 +26,15 @@ namespace ProcNet.Tests
 			return binaryFolder;
 		}
 
+		protected static StartArguments CmdTestCaseArguments(string testcase, params string[] args) {
+			string[] arguments = ["/C", "dotnet", GetDll(), testcase];
+
+			return new StartArguments("cmd", arguments.Concat(args)) {
+				WorkingDirectory = GetWorkingDir(),
+				Timeout = WaitTimeout
+			};
+		}
+
 		protected static StartArguments TestCaseArguments(string testcase, params string[] args)
 		{
 			string[] arguments = [GetDll(), testcase];


### PR DESCRIPTION
Fixed an issue where a 'The pipe is being closed' IOException is thrown when a CMD process doesn't exit naturally from the `Control+C` sent to it when attempting to stop the process, and is instead force killed after the wait time specified for the stop.