### PR TITLE
Fix InvalidOperationException when disposing incomplete task in HardWaitForExit

### DIFF
--- a/src/Proc/Proc.Exec.cs
+++ b/src/Proc/Proc.Exec.cs
@@ -78,7 +78,7 @@ namespace ProcNet
 
 		private static void HardWaitForExit(Process process, TimeSpan timeSpan)
 		{
-			using var task = Task.Run(() => process.WaitForExit());
+			var task = Task.Run(() => process.WaitForExit());
 			Task.WaitAny(task, Task.Delay(timeSpan));
 		}
 	}

--- a/src/Proc/Proc.ExecAsync.cs
+++ b/src/Proc/Proc.ExecAsync.cs
@@ -65,7 +65,7 @@ namespace ProcNet
 
 		private static async Task HardWaitForExitAsync(Process process, TimeSpan timeSpan)
 		{
-			using var task = Task.Run(() => process.WaitForExitAsync());
+			var task = Task.Run(() => process.WaitForExitAsync());
 			await Task.WhenAny(task, Task.Delay(timeSpan));
 		}
 	}


### PR DESCRIPTION
Remove `using` from Task declarations in HardWaitForExit and HardWaitForExitAsync.
When the timeout delay completes before WaitForExit, the using block attempted to
dispose a still-running task, causing "A task may only be disposed if it is in a
completion state" exception. Tasks don't need explicit disposal per MSDN guidance.
