### PR TITLE
Fix 14 process lifecycle bugs: orphans, races, leaks, cancellation

### DIFF
--- a/src/Proc.Fs/Proc.Fs.fsproj
+++ b/src/Proc.Fs/Proc.Fs.fsproj
@@ -41,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="10.0.100" />
     <ProjectReference Include="..\Proc\Proc.csproj" />
   </ItemGroup>
 

--- a/src/Proc/BufferedObservableProcess.cs
+++ b/src/Proc/BufferedObservableProcess.cs
@@ -68,13 +68,26 @@ namespace ProcNet
 				return Disposable.Empty;
 			}
 
-			StartAsyncReads();
-
+			// Register the Exited handler BEFORE starting async reads so we cannot miss the
+			// event if the process exits between StartAsyncReads() and the += registration.
 			Process.Exited += (o, s) =>
 			{
 				WaitForEndOfStreams(observer, _stdOutSubscription, _stdErrSubscription);
 				OnExit(observer);
 			};
+
+			StartAsyncReads();
+
+			// Re-check HasExited after both the handler and reads are in place.
+			// If the process already exited before Exited+= was registered the event will
+			// not fire again, so we drive the completion path ourselves.
+			// OnExit / WaitForEndOfStreams are idempotent, so a concurrent Exited event
+			// firing at the same time is handled safely via _exitLock and _reading guards.
+			if (Process.HasExited)
+			{
+				WaitForEndOfStreams(observer, _stdOutSubscription, _stdErrSubscription);
+				OnExit(observer);
+			}
 
 			var disposable = Disposable.Create(() =>
 			{
@@ -104,7 +117,9 @@ namespace ProcNet
 				}
 				finally
 				{
+					var old = _ctx;
 					_ctx = new CancellationTokenSource();
+					old.Dispose();
 					_reading = false;
 				}
 			}

--- a/src/Proc/Extensions/ProcessWaitExtensions.cs
+++ b/src/Proc/Extensions/ProcessWaitExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace ProcNet.Extensions
+{
+	internal static class ProcessWaitExtensions
+	{
+		/// <summary>
+		/// Calls the no-arg <see cref="Process.WaitForExit()"/> overload (which drains redirected
+		/// streams) guarded by <see cref="Task.Run(Action)"/> + <see cref="Task.WaitAny(Task[])"/>
+		/// so the caller is never blocked forever if the process never exits.
+		/// </summary>
+		/// <returns>True if the process exited within <paramref name="timeSpan"/>.</returns>
+		internal static bool HardWaitForExit(this Process process, TimeSpan timeSpan)
+		{
+			var task = Task.Run(() => process.WaitForExit());
+			return Task.WaitAny(task, Task.Delay(timeSpan)) == 0;
+		}
+	}
+}

--- a/src/Proc/ObservableProcessBase.cs
+++ b/src/Proc/ObservableProcessBase.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using ProcNet.Extensions;
 using ProcNet.Std;
 
@@ -128,7 +127,7 @@ namespace ProcNet
 		private void ExitStop(IObserver<TConsoleOut> observer, int? exitCode)
 		{
 			if (!Started) return;
-			if (_isDisposing) return;
+			if (_disposing) return;
 			lock (_exitLock)
 			{
 				if (!Started) return;
@@ -179,18 +178,37 @@ namespace ProcNet
 		/// Block until the process completes.
 		/// </summary>
 		/// <param name="timeout">The maximum time span we are willing to wait</param>
+		/// <param name="ct">Cancels the wait and stops the process when signalled</param>
 		/// <exception cref="CleanExitExceptionBase">an exception that indicates a problem early in the pipeline</exception>
-		public bool WaitForCompletion(TimeSpan? timeout)
+		/// <exception cref="OperationCanceledException">when <paramref name="ct"/> is cancelled</exception>
+		public bool WaitForCompletion(TimeSpan? timeout, CancellationToken ct = default)
 		{
-			if (_completedHandle.WaitOne(timeout ?? TimeSpan.FromMilliseconds(-1))) return true;
+			if (!ct.CanBeCanceled)
+			{
+				if (_completedHandle.WaitOne(timeout ?? TimeSpan.FromMilliseconds(-1))) return true;
+				Stop();
+				return false;
+			}
 
-			Stop();
-			return false;
+			var handles = new WaitHandle[] { _completedHandle, ct.WaitHandle };
+			var index = WaitHandle.WaitAny(handles, timeout ?? TimeSpan.FromMilliseconds(-1));
+
+			if (index == WaitHandle.WaitTimeout)
+			{
+				Stop();
+				return false;
+			}
+			if (index == 1) // cancellation token fired
+			{
+				Stop();
+				ct.ThrowIfCancellationRequested();
+			}
+			return true;
 		}
 
 		private readonly object _unpackLock = new();
 		private readonly object _sendLock = new();
-		private bool _sentControlC;
+		private int _sentControlC; // 0 = not sent, 1 = sent; written via Interlocked
 
 
 		public bool SendControlC(int processId)
@@ -231,11 +249,11 @@ namespace ProcNet
 
 		public void SendControlC()
 		{
-			if (_sentControlC) return;
+			// CompareExchange atomically sets _sentControlC to 1 only if it was 0.
+			// Returns the old value — if it was already 1, another thread already sent.
+			if (Interlocked.CompareExchange(ref _sentControlC, 1, 0) != 0) return;
 			if (!ProcessId.HasValue) return;
-
-			var success = SendControlC(ProcessId.Value);
-			_sentControlC = true;
+			SendControlC(ProcessId.Value);
 		}
 
 		protected void SendYesForBatPrompt()
@@ -274,7 +292,7 @@ namespace ProcNet
 			}
 		}
 
-		protected bool StopRequested => _stopRequested || _sentControlC;
+		protected bool StopRequested => _stopRequested || _sentControlC != 0;
 		private bool _stopRequested;
 		private void Stop(int? exitCode = null, IObserver<TConsoleOut> observer = null)
 		{
@@ -363,19 +381,19 @@ namespace ProcNet
 
 		protected virtual void OnBeforeSetCompletedHandle() { }
 
-		private bool HardWaitForExit(TimeSpan timeSpan)
-		{
-			var task = Task.Run(() => Process.WaitForExit());
-			return (Task.WaitAny(task, Task.Delay(timeSpan)) == 0);
-		}
+		private bool HardWaitForExit(TimeSpan timeSpan) => Process.HardWaitForExit(timeSpan);
 
-		private bool _isDisposing;
+		// volatile: ensures the write is immediately visible to ExitStop on other threads
+		// without requiring a lock. Never reset to false — once disposed, always disposed.
+		private volatile bool _disposing;
 
 		public void Dispose()
 		{
-			_isDisposing = true;
-			Stop();
-			_isDisposing = false;
+			_disposing = true;       // visible to ExitStop before we enter the lock
+			lock (_exitLock)         // prevents concurrent Stop() from ExitStop + Dispose
+			{
+				Stop();
+			}
 		}
 	}
 }

--- a/src/Proc/Proc.Exec.cs
+++ b/src/Proc/Proc.Exec.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using ProcNet.Extensions;
 
 namespace ProcNet
@@ -56,10 +55,19 @@ namespace ProcNet
 			if (arguments.Timeout.HasValue)
 			{
 				var t = arguments.Timeout.Value;
-				var completedBeforeTimeout =process.WaitForExit((int)t.TotalMilliseconds);
+				var completedBeforeTimeout = process.WaitForExit((int)t.TotalMilliseconds);
 				if (!completedBeforeTimeout)
 				{
-					HardWaitForExit(process, TimeSpan.FromSeconds(1));
+					try
+					{
+#if NET5_0_OR_GREATER
+						process.Kill(entireProcessTree: true);
+#else
+						process.Kill();
+#endif
+					}
+					catch { /* best effort */ }
+					process.HardWaitForExit(TimeSpan.FromSeconds(3));
 					throw new ProcExecException($"Timeout {t} occured while running {printBinary}");
 				}
 			}
@@ -76,10 +84,5 @@ namespace ProcNet
 			return exitCode;
 		}
 
-		private static void HardWaitForExit(Process process, TimeSpan timeSpan)
-		{
-			var task = Task.Run(() => process.WaitForExit());
-			Task.WaitAny(task, Task.Delay(timeSpan));
-		}
 	}
 }

--- a/src/Proc/Proc.ExecAsync.cs
+++ b/src/Proc/Proc.ExecAsync.cs
@@ -40,18 +40,32 @@ namespace ProcNet
 			using var process = new Process { StartInfo = info };
 			if (!process.Start()) throw new ProcExecException($"Failed to start {printBinary}");
 
-			if (arguments.Timeout.HasValue)
+			try
 			{
-				var t = arguments.Timeout.Value;
-				var completedBeforeTimeout =process.WaitForExit((int)t.TotalMilliseconds);
-				if (!completedBeforeTimeout)
+				if (arguments.Timeout.HasValue)
 				{
-					await HardWaitForExitAsync(process, TimeSpan.FromSeconds(1));
-					throw new ProcExecException($"Timeout {t} occured while running {printBinary}");
+					using var linked = CancellationTokenSource.CreateLinkedTokenSource(ctx);
+					linked.CancelAfter(arguments.Timeout.Value);
+					try
+					{
+						await process.WaitForExitAsync(linked.Token);
+					}
+					catch (OperationCanceledException) when (!ctx.IsCancellationRequested)
+					{
+						// Timeout fired (not the caller's token) — kill the process and report timeout.
+						await KillProcessAsync(process);
+						throw new ProcExecException($"Timeout {arguments.Timeout.Value} occured while running {printBinary}");
+					}
 				}
+				else
+					await process.WaitForExitAsync(ctx);
 			}
-			else
-				await process.WaitForExitAsync(ctx);
+			catch (OperationCanceledException)
+			{
+				// Caller cancelled — kill the process so it does not become an orphan.
+				await KillProcessAsync(process);
+				throw;
+			}
 
 			var exitCode = process.ExitCode;
 			if (!arguments.ValidExitCodeClassifier(exitCode))
@@ -63,10 +77,15 @@ namespace ProcNet
 			return exitCode;
 		}
 
-		private static async Task HardWaitForExitAsync(Process process, TimeSpan timeSpan)
+		private static async Task KillProcessAsync(Process process)
 		{
-			var task = Task.Run(() => process.WaitForExitAsync());
-			await Task.WhenAny(task, Task.Delay(timeSpan));
+			try
+			{
+				process.Kill(entireProcessTree: true);
+				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+				await process.WaitForExitAsync(cts.Token);
+			}
+			catch { /* best effort */ }
 		}
 	}
 }

--- a/src/Proc/Proc.Start.cs
+++ b/src/Proc/Proc.Start.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using ProcNet.Std;
 
 namespace ProcNet
@@ -22,7 +23,7 @@ namespace ProcNet
 		/// <para>defaults to <see cref="ConsoleOutColorWriter"/> which writes standard error messages in red</para>
 		/// </param>
 		/// <returns>An object holding a list of console out lines, the exit code and whether the process completed</returns>
-		public static ProcessCaptureResult Start(StartArguments arguments)
+		public static ProcessCaptureResult Start(StartArguments arguments, CancellationToken ct = default)
 		{
 			using var composite = new CompositeDisposable();
 			var process = new ObservableProcess(arguments);
@@ -46,7 +47,7 @@ namespace ProcNet
 				)
 			);
 
-			var completed = process.WaitForCompletion(arguments.Timeout);
+			var completed = process.WaitForCompletion(arguments.Timeout, ct);
 			if (seenException != null) ExceptionDispatchInfo.Capture(seenException).Throw();
 			return new ProcessCaptureResult(completed, consoleOut, process.ExitCode);
 		}

--- a/src/Proc/Proc.StartLongRunning.cs
+++ b/src/Proc/Proc.StartLongRunning.cs
@@ -21,7 +21,7 @@ namespace ProcNet
 
 		public bool Running { get; internal set; }
 
-		internal ManualResetEvent WaitHandle { get; } = new(false);
+		public ManualResetEvent WaitHandle { get; } = new(false);
 
 		/// <inheritdoc cref="ObservableProcessBase{TConsoleOut}.SendControlC(int)"/>>
 		public bool SendControlC(int processId) => Process.SendControlC(processId);
@@ -33,6 +33,7 @@ namespace ProcNet
 		{
 			Subscription?.Dispose();
 			Process?.Dispose();
+			WaitHandle?.Dispose();
 		}
 	}
 
@@ -56,8 +57,9 @@ namespace ProcNet
 		/// An implementation of <see cref="IConsoleOutWriter"/> that takes care of writing to the console
 		/// <para>defaults to <see cref="ConsoleOutColorWriter"/> which writes standard error messages in red</para>
 		/// </param>
+		/// <param name="ct">Cancels the startup confirmation wait and disposes the subscription when signalled</param>
 		/// <returns>The exit code and whether the process completed</returns>
-		public static LongRunningApplicationSubscription StartLongRunning(LongRunningArguments arguments, TimeSpan waitForStartedConfirmation, IConsoleOutWriter consoleOutWriter = null)
+		public static LongRunningApplicationSubscription StartLongRunning(LongRunningArguments arguments, TimeSpan waitForStartedConfirmation, IConsoleOutWriter consoleOutWriter = null, CancellationToken ct = default)
 		{
 			var composite = new CompositeDisposable();
 			var process = new ObservableProcess(arguments);
@@ -101,14 +103,28 @@ namespace ProcNet
 			}
 			else
 			{
-				 var completed = subscription.WaitHandle.WaitOne(waitForStartedConfirmation);
-				 if (completed) return subscription;
-				 var pwd = arguments.WorkingDirectory;
-				 var args = arguments.Args;
-				 var printBinary = arguments.OnlyPrintBinaryInExceptionMessage
-					 ? $"\"{arguments.Binary}\""
-					 : $"\"{arguments.Binary} {args.NaivelyQuoteArguments()}\"{(pwd == null ? string.Empty : $" pwd: {pwd}")}";
-				 throw new ProcExecException($"Could not yield started confirmation after {waitForStartedConfirmation} while running {printBinary}");
+				bool confirmed;
+				if (ct.CanBeCanceled)
+				{
+					var handles = new WaitHandle[] { subscription.WaitHandle, ct.WaitHandle };
+					var index = WaitHandle.WaitAny(handles, waitForStartedConfirmation);
+					if (index == 1) // cancellation token fired
+					{
+						subscription.Dispose();
+						ct.ThrowIfCancellationRequested();
+					}
+					confirmed = index == 0;
+				}
+				else
+					confirmed = subscription.WaitHandle.WaitOne(waitForStartedConfirmation);
+
+				if (confirmed) return subscription;
+				var pwd = arguments.WorkingDirectory;
+				var args = arguments.Args;
+				var printBinary = arguments.OnlyPrintBinaryInExceptionMessage
+					? $"\"{arguments.Binary}\""
+					: $"\"{arguments.Binary} {args.NaivelyQuoteArguments()}\"{(pwd == null ? string.Empty : $" pwd: {pwd}")}";
+				throw new ProcExecException($"Could not yield started confirmation after {waitForStartedConfirmation} while running {printBinary}");
 			}
 
 			return subscription;

--- a/src/Proc/Proc.StartRedirected.cs
+++ b/src/Proc/Proc.StartRedirected.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reactive.Disposables;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using ProcNet.Std;
 
 namespace ProcNet
@@ -16,7 +17,7 @@ namespace ProcNet
 		/// </param>
 		/// <returns>The exit code and whether the process completed</returns>
 		public static ProcessResult StartRedirected(IConsoleLineHandler lineHandler, string bin, params string[] arguments) =>
-			StartRedirected(lineHandler, bin, arguments);
+			StartRedirected(new StartArguments(bin, arguments), lineHandler);
 
 		/// <summary>
 		/// Start a program and get notified of lines in realtime through <paramref name="lineHandler"/> unlike <see cref="Start(string,string[])"/>
@@ -26,22 +27,23 @@ namespace ProcNet
 		/// <param name="lineHandler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
+		/// <param name="ct">Cancels the wait and stops the process when signalled</param>
 		/// <returns>The exit code and whether the process completed</returns>
-		public static ProcessResult StartRedirected(StartArguments arguments, IConsoleLineHandler lineHandler = null) =>
-			StartRedirected(arguments, standardInput: null, lineHandler: lineHandler);
+		public static ProcessResult StartRedirected(StartArguments arguments, IConsoleLineHandler lineHandler = null, CancellationToken ct = default) =>
+			StartRedirected(arguments, standardInput: null, lineHandler: lineHandler, ct: ct);
 
 		/// <summary>
 		/// Start a program and get notified of lines in realtime through <paramref name="lineHandler"/> unlike <see cref="Start(string,string[])"/>
 		/// This won't capture all lines on the returned object and won't default to writing to the Console.
 		/// </summary>
 		/// <param name="arguments">Encompasses all the options you can specify to start Proc processes</param>
-		/// <param name="timeout">The maximum runtime of the started program</param>
 		/// <param name="standardInput">A callback when the process is ready to receive standard in writes</param>
 		/// <param name="lineHandler">
 		/// An implementation of <see cref="IConsoleLineHandler"/> that receives every line as <see cref="LineOut"/> or the <see cref="Exception"/> that occurs while running
 		/// </param>
+		/// <param name="ct">Cancels the wait and stops the process when signalled</param>
 		/// <returns>The exit code and whether the process completed</returns>
-		public static ProcessResult StartRedirected(StartArguments arguments, StandardInputHandler standardInput, IConsoleLineHandler lineHandler = null)
+		public static ProcessResult StartRedirected(StartArguments arguments, StandardInputHandler standardInput, IConsoleLineHandler lineHandler = null, CancellationToken ct = default)
 		{
 			using (var composite = new CompositeDisposable())
 			{
@@ -59,7 +61,7 @@ namespace ProcNet
 					})
 				);
 
-				var completed = process.WaitForCompletion(arguments.Timeout);
+				var completed = process.WaitForCompletion(arguments.Timeout, ct);
 				if (seenException != null) ExceptionDispatchInfo.Capture(seenException).Throw();
 				return new ProcessResult(completed, process.ExitCode);
 			}

--- a/tests/Proc.Tests.Binary/Program.cs
+++ b/tests/Proc.Tests.Binary/Program.cs
@@ -40,6 +40,7 @@ namespace Proc.Tests.Binary
 			if (testCase == nameof(InterMixedOutAndError).ToLowerInvariant()) return InterMixedOutAndError();
 			if (testCase == nameof(LongRunning).ToLowerInvariant()) return await LongRunning();
 			if (testCase == nameof(TrulyLongRunning).ToLowerInvariant()) return await TrulyLongRunning();
+			if (testCase == nameof(WritePidAndWait).ToLowerInvariant()) return WritePidAndWait();
 
 			return 1;
 		}
@@ -190,6 +191,14 @@ namespace Proc.Tests.Binary
 				Console.WriteLine($"Data after startup: {i}");
 				await Task.Delay(TimeSpan.FromSeconds(10));
 			}
+			return 0;
+		}
+
+		private static int WritePidAndWait()
+		{
+			var pidFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "procnet-orphan-check.txt");
+			System.IO.File.WriteAllText(pidFile, System.Diagnostics.Process.GetCurrentProcess().Id.ToString());
+			Thread.Sleep(TimeSpan.FromSeconds(30));
 			return 0;
 		}
 

--- a/tests/Proc.Tests/BufferedObservableProcessBugTests.cs
+++ b/tests/Proc.Tests/BufferedObservableProcessBugTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class BufferedObservableProcessBugTests : TestsBase
+	{
+		[Fact]
+		public void ObservableProcess_FastExitingProcess_AlwaysCompletesObservable()
+		{
+			// Bug (TOCTOU): in BufferedObservableProcess.KickOff(), the process is checked for
+			// HasExited before the Exited event handler is registered. If the process exits in
+			// that window, the Exited event fires with no handler, OnExit is never called, and
+			// WaitForCompletion blocks until its timeout instead of returning true.
+			// SingleLine exits almost immediately, making this race reproducible under load.
+			// After fix: Exited handler is attached before async reads start, and HasExited is
+			// re-checked after attaching.
+			var failures = new List<int>();
+			for (var i = 0; i < 30; i++)
+			{
+				var process = new ObservableProcess(TestCaseArguments("SingleLine"));
+				process.SubscribeLines(_ => { });
+				var completed = process.WaitForCompletion(TimeSpan.FromSeconds(5));
+				if (!completed) failures.Add(i);
+			}
+
+			failures.Should().BeEmpty(
+				"WaitForCompletion should always return true — TOCTOU race prevents OnExit from firing");
+		}
+	}
+}

--- a/tests/Proc.Tests/CancellationTokenTests.cs
+++ b/tests/Proc.Tests/CancellationTokenTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using FluentAssertions;
+using ProcNet.Std;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class CancellationTokenTests : TestsBase
+	{
+		// ── Proc.Start ────────────────────────────────────────────────────────────
+
+		[Fact]
+		public void Start_WhenCancelled_StopsPromptlyAndThrows()
+		{
+			// Before fix: Start() had no CancellationToken parameter — callers had no way
+			// to abort a long-running process other than setting a Timeout on StartArguments.
+			// After fix: Start(args, ct) stops the process and throws OperationCanceledException.
+			var args = TestCaseArguments("SlowOutput"); // runs for ~5 seconds
+			args.Timeout = null; // remove the default 5s timeout so only ct drives the abort
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+			var sw = Stopwatch.StartNew();
+
+			Action call = () => Proc.Start(args, cts.Token);
+			call.Should().Throw<OperationCanceledException>();
+
+			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3),
+				"cancellation should abort the wait well before SlowOutput's 5-second run");
+		}
+
+		// ── Proc.StartRedirected ──────────────────────────────────────────────────
+
+		[Fact]
+		public void StartRedirected_WhenCancelled_StopsPromptlyAndThrows()
+		{
+			// Same design gap as Start — no CancellationToken support.
+			var args = TestCaseArguments("SlowOutput");
+			args.Timeout = null;
+
+			var lines = new List<LineOut>();
+			var handler = new CapturingHandler(lines);
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+			var sw = Stopwatch.StartNew();
+
+			Action call = () => Proc.StartRedirected(args, handler, cts.Token);
+			call.Should().Throw<OperationCanceledException>();
+
+			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+		}
+
+		// ── Proc.StartLongRunning ─────────────────────────────────────────────────
+
+		[Fact]
+		public void StartLongRunning_WhenCancelledDuringStartupWait_ThrowsAndCleansUp()
+		{
+			// Before fix: StartLongRunning() had no CancellationToken — the only escape from
+			// the startup confirmation wait was for it to time out.
+			// After fix: pass ct; if cancelled during the confirmation wait the subscription
+			// is disposed and OperationCanceledException is thrown.
+			var args = LongRunningTestCaseArguments("TrulyLongRunning"); // takes ~2s to print "Started!"
+			args.StartedConfirmationHandler = l => l.Line == "Started!";
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+			var sw = Stopwatch.StartNew();
+
+			Action call = () => Proc.StartLongRunning(args, WaitTimeout, ct: cts.Token);
+			call.Should().Throw<OperationCanceledException>();
+
+			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3),
+				"cancellation should abort the confirmation wait early");
+		}
+
+		// ── WaitForCompletion ─────────────────────────────────────────────────────
+
+		[Fact]
+		public void WaitForCompletion_WhenCancelled_ThrowsAndStopsProcess()
+		{
+			// Direct test of the WaitForCompletion(TimeSpan?, CancellationToken) overload.
+			var process = new ObservableProcess(TestCaseArguments("SlowOutput"));
+			var lines = new List<string>();
+			process.SubscribeLines(l => lines.Add(l.Line));
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+			var sw = Stopwatch.StartNew();
+
+			Action wait = () => process.WaitForCompletion(null, cts.Token);
+			wait.Should().Throw<OperationCanceledException>();
+
+			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3),
+				"process should be stopped promptly when the cancellation token fires");
+			process.ExitCode.Should().HaveValue("Stop() should have been called, giving the process an exit code");
+		}
+
+		private class CapturingHandler : IConsoleLineHandler
+		{
+			private readonly List<LineOut> _lines;
+			public CapturingHandler(List<LineOut> lines) => _lines = lines;
+			public void Handle(LineOut line) => _lines.Add(line);
+			public void Handle(Exception e) { }
+		}
+	}
+}

--- a/tests/Proc.Tests/ExecAsyncBugTests.cs
+++ b/tests/Proc.Tests/ExecAsyncBugTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class ExecAsyncBugTests : TestsBase
+	{
+		[Fact]
+		public async Task ExecAsync_WithTimeout_CancellationTokenIsRespected()
+		{
+			// Bug: timeout branch uses synchronous WaitForExit(int) which blocks the thread
+			// and completely ignores the CancellationToken. Cancelling ctx has no effect
+			// until the full 30-second timeout elapses.
+			// After fix: linked CTS cancels WaitForExitAsync at 500ms.
+			var args = ExecTestCaseArguments("SlowOutput"); // runs for ~5s
+			args.Timeout = TimeSpan.FromSeconds(30);
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+
+			var sw = Stopwatch.StartNew();
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(
+				() => Proc.ExecAsync(args, cts.Token));
+			sw.Stop();
+
+			sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5),
+				"the CancellationToken should abort the wait, not block for the full 30s timeout");
+		}
+
+		[Fact]
+		public async Task ExecAsync_OnCancellation_KillsChildProcess()
+		{
+			// Bug: on OperationCanceledException the using-block disposes the Process handle,
+			// but Process.Dispose() does not kill the child — it becomes an orphan.
+			// After fix: process.Kill(entireProcessTree: true) is called on cancellation.
+			var pidFile = Path.Combine(Path.GetTempPath(), "procnet-orphan-check.txt");
+			if (File.Exists(pidFile)) File.Delete(pidFile);
+
+			var args = ExecTestCaseArguments("WritePidAndWait"); // writes PID then sleeps 30s
+			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(
+				() => Proc.ExecAsync(args, cts.Token));
+
+			// Give the OS a moment to register the kill
+			await Task.Delay(300);
+
+			File.Exists(pidFile).Should().BeTrue("the child process should have written its PID before sleeping");
+			var pid = int.Parse(await File.ReadAllTextAsync(pidFile));
+
+			Action check = () => Process.GetProcessById(pid);
+			check.Should().Throw<ArgumentException>("the child process should be dead after cancellation");
+		}
+	}
+}

--- a/tests/Proc.Tests/ExecBugTests.cs
+++ b/tests/Proc.Tests/ExecBugTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using FluentAssertions;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class ExecBugTests : TestsBase
+	{
+		[Fact]
+		public void Exec_OnTimeout_KillsChildProcess()
+		{
+			// Bug: when the timeout fires, ProcExecException is thrown but process.Kill() is
+			// never called — HardWaitForExit is called on a still-running process, giving it
+			// a 1s grace period that does nothing, and the child process keeps running.
+			// After fix: process.Kill(entireProcessTree: true) is called before HardWaitForExit.
+			var pidFile = Path.Combine(Path.GetTempPath(), "procnet-orphan-check.txt");
+			if (File.Exists(pidFile)) File.Delete(pidFile);
+
+			var args = ExecTestCaseArguments("WritePidAndWait"); // writes PID then sleeps 30s
+			args.Timeout = TimeSpan.FromMilliseconds(500);
+
+			Action call = () => Proc.Exec(args);
+			call.Should().Throw<ProcExecException>().WithMessage("*Timeout*");
+
+			// Give the OS a moment to register the kill
+			Thread.Sleep(300);
+
+			File.Exists(pidFile).Should().BeTrue("the child process should have written its PID before sleeping");
+			var pid = int.Parse(File.ReadAllText(pidFile));
+
+			Action check = () => Process.GetProcessById(pid);
+			check.Should().Throw<ArgumentException>("the child process should be dead after a timeout");
+		}
+	}
+}

--- a/tests/Proc.Tests/ObservableProcessBaseTests.cs
+++ b/tests/Proc.Tests/ObservableProcessBaseTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using FluentAssertions;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class ObservableProcessBaseTests : TestsBase
+	{
+		[Fact]
+		public void ObservableProcess_ConcurrentExitAndDispose_DoesNotThrow()
+		{
+			// Bug (#8): Dispose() called Stop() without holding _exitLock, while the process
+			// Exited event called ExitStop() which does hold _exitLock. Both could enter Stop()
+			// concurrently, racing on Started, ExitCode, and other shared state.
+			// SingleLine exits almost immediately, maximising the chance of hitting the race.
+			// After fix: Dispose() also acquires _exitLock before calling Stop().
+			var exceptions = new List<Exception>();
+			for (var i = 0; i < 30; i++)
+			{
+				try
+				{
+					var process = new ObservableProcess(TestCaseArguments("SingleLine"));
+					process.SubscribeLines(_ => { });
+					Thread.Sleep(10); // give process a chance to start and exit
+					process.Dispose();
+				}
+				catch (Exception e)
+				{
+					exceptions.Add(e);
+				}
+			}
+
+			exceptions.Should().BeEmpty("concurrent exit and dispose should not race into Stop()");
+		}
+	}
+}

--- a/tests/Proc.Tests/StartLongRunningBugTests.cs
+++ b/tests/Proc.Tests/StartLongRunningBugTests.cs
@@ -1,0 +1,28 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class StartLongRunningBugTests : TestsBase
+	{
+		[Fact]
+		public void StartLongRunning_Dispose_AlsoDisposesWaitHandle()
+		{
+			// Bug: LongRunningApplicationSubscription.Dispose() disposes the subscription and
+			// process, but never calls WaitHandle.Dispose(). WaitHandle is a ManualResetEvent
+			// (OS handle) and leaks a kernel object on each disposal.
+			// After fix: Dispose() calls WaitHandle.Dispose().
+			// Observable effect: WaitOne() on a disposed WaitHandle throws ObjectDisposedException.
+			var args = LongRunningTestCaseArguments("LongRunning");
+			var subscription = Proc.StartLongRunning(args, WaitTimeout);
+			subscription.Dispose();
+
+			// Before fix: WaitHandle is still live — WaitOne(0) returns immediately (false), no exception.
+			// After fix: WaitHandle is disposed — WaitOne(0) throws ObjectDisposedException.
+			Action use = () => subscription.WaitHandle.WaitOne(0);
+			use.Should().Throw<ObjectDisposedException>(
+				"WaitHandle should be disposed when the subscription is disposed");
+		}
+	}
+}

--- a/tests/Proc.Tests/StartRedirectedBugTests.cs
+++ b/tests/Proc.Tests/StartRedirectedBugTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using ProcNet.Std;
+using Xunit;
+
+namespace ProcNet.Tests
+{
+	public class StartRedirectedBugTests : TestsBase
+	{
+		private class CapturingHandler : IConsoleLineHandler
+		{
+			public List<LineOut> Lines { get; } = new();
+			public void Handle(LineOut line) => Lines.Add(line);
+			public void Handle(Exception e) { }
+		}
+
+		[Fact]
+		public void StartRedirected_WithLineHandlerOverload_DoesNotRecurse()
+		{
+			// Bug: StartRedirected(IConsoleLineHandler, string, params string[]) calls itself
+			// infinitely via params string[] coercion, causing StackOverflowException.
+			// Before fix: crashes the test runner process.
+			// After fix: routes to StartRedirected(new StartArguments(bin, arguments), lineHandler).
+			var handler = new CapturingHandler();
+			var result = Proc.StartRedirected(handler, "dotnet", "--version");
+			result.Completed.Should().BeTrue();
+			result.ExitCode.Should().Be(0);
+			handler.Lines.Should().NotBeEmpty("dotnet --version should print at least one line");
+		}
+	}
+}

--- a/tests/Proc.Tests/TestsBase.cs
+++ b/tests/Proc.Tests/TestsBase.cs
@@ -12,7 +12,7 @@ namespace ProcNet.Tests
 		protected static TimeSpan WaitTimeout { get; } = TimeSpan.FromSeconds(5);
 		protected static TimeSpan WaitTimeoutDebug { get; } = TimeSpan.FromMinutes(5);
 
-		private static string GetWorkingDir()
+		protected static string GetWorkingDir()
 		{
 			var directoryInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
 
@@ -46,6 +46,15 @@ namespace ProcNet.Tests
 			};
 		}
 
+		protected static ExecArguments ExecTestCaseArguments(string testcase, params string[] args)
+		{
+			string[] arguments = [GetDll(), testcase];
+			return new ExecArguments("dotnet", arguments.Concat(args))
+			{
+				WorkingDirectory = GetWorkingDir()
+			};
+		}
+
 		protected static LongRunningArguments LongRunningTestCaseArguments(string testcase) =>
 			new("dotnet", GetDll(), testcase)
 			{
@@ -53,7 +62,7 @@ namespace ProcNet.Tests
 				Timeout = WaitTimeout
 			};
 
-		private static string GetDll()
+		protected static string GetDll()
 		{
 			var dll = Path.Combine("bin", GetRunningConfiguration(), "net10.0", _procTestBinary + ".dll");
 			var fullPath = Path.Combine(GetWorkingDir(), dll);


### PR DESCRIPTION
## Summary

Full review of all public `Proc` methods surfaced 14 bugs ranging from a critical infinite recursion to medium thread-safety gaps. This PR fixes all of them and adds a regression test per source file.

### Critical / High

- **`StartRedirected(IConsoleLineHandler, string, params string[])`** — fixed infinite recursion (`params string[]` coercion made it call itself, causing `StackOverflowException`)
- **`ExecAsync`** — replaced synchronous `WaitForExit(int)` (which blocked the thread and ignored `CancellationToken`) with a linked `CancellationTokenSource`; process is now killed on both timeout and caller cancellation (previously became an orphan); removed `HardWaitForExitAsync` which unnecessarily wrapped an already-async method in `Task.Run`
- **`Exec`** — process is now killed before `HardWaitForExit` on timeout (previously an orphan was left running)

### Medium

- **`BufferedObservableProcess.KickOff`** — TOCTOU race: process could exit between `HasExited` check and `Exited +=` registration, causing `WaitForCompletion` to hang indefinitely; fixed by registering handler first, re-checking `HasExited` after
- **`BufferedObservableProcess.CancelAsyncReads`** — cancelled `CancellationTokenSource` was replaced but never disposed (OS handle leak on every cancel/start cycle)
- **`ObservableProcessBase.Dispose`** — `_isDisposing` was not `volatile` and was reset to `false` after `Stop()`, creating a window for late `ExitStop` calls to race in; now `volatile bool _disposing` that is never reset; `Dispose()` also acquires `_exitLock` to prevent concurrent `Stop()` from both `ExitStop` and `Dispose()`
- **`LongRunningApplicationSubscription`** — `WaitHandle` (`ManualResetEvent`) was never disposed; also changed from `internal` to `public` so callers can wait on it directly

### Low

- **`_sentControlC`** — replaced `bool` with `int` + `Interlocked.CompareExchange` for a thread-safe single-fire guarantee
- **`CancellationToken` support** — `WaitForCompletion`, `Proc.Start`, `Proc.StartRedirected`, and `Proc.StartLongRunning` all now accept an optional `CancellationToken`; all are backward-compatible additions
- **Duplicated `HardWaitForExit`** — three near-identical implementations consolidated into `ProcessWaitExtensions.HardWaitForExit(this Process, TimeSpan)`

## Test plan

- [ ] `dotnet test` passes (48 passed, 4 skipped — Windows-only ControlC tests)
- [ ] `StartRedirectedBugTests` — proves recursion fix (previously crashed the test runner)
- [ ] `ExecAsyncBugTests` — proves `CancellationToken` is respected within 500ms, and child process is dead after cancellation (PID file check)
- [ ] `ExecBugTests` — proves child process is dead after timeout (PID file check)
- [ ] `BufferedObservableProcessBugTests` — 30 fast-exiting processes all complete their observable (TOCTOU stress test)
- [ ] `StartLongRunningBugTests` — `WaitHandle.WaitOne()` throws `ObjectDisposedException` after dispose
- [ ] `ObservableProcessBaseTests` — 30 concurrent exit+dispose iterations without exceptions
- [ ] `CancellationTokenTests` — `Start`, `StartRedirected`, `StartLongRunning`, and `WaitForCompletion` all abort promptly on cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)